### PR TITLE
Minor adjustments on product-description page media query's layout

### DIFF
--- a/src/components/CartPage/index.js
+++ b/src/components/CartPage/index.js
@@ -70,7 +70,7 @@ export default function Cart() {
                   />
                 );
               })
-            : emptyCart()}
+            : () => emptyCart()}
         </div>
 
         <footer>

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -125,11 +125,8 @@ export default function MainPage() {
             <IoSearchSharp className="search-icon" />
           </SearchField>
 
-          <span className="cart-icon">
-            <IoCartOutline
-              onClick={() => navigate("/cart")}
-              className="nav-icon"
-            />
+          <span onClick={() => navigate("/cart")} className="cart-icon">
+            <IoCartOutline className="nav-icon" />
 
             {getTotal() > 0 ? (
               <div className="cartProductIndicator">{getTotal()}</div>

--- a/src/components/ProductPage/Product.js
+++ b/src/components/ProductPage/Product.js
@@ -1,10 +1,12 @@
-﻿import { useContext } from "react";
-import styled from "styled-components";
+﻿import { useState, useContext } from "react";
+import { Bars } from "react-loader-spinner";
 import { v4 as uuidv4 } from "uuid";
+import styled from "styled-components";
 
 import ProductDataContext from "../../context/ProductDataContext";
 
 export default function Product() {
+  const [loading] = useState(<Bars />);
   const { productData } = useContext(ProductDataContext);
 
   return (
@@ -12,9 +14,9 @@ export default function Product() {
       <ProductImagesComponent>
         {productData
           ? productData.images.map(({ src, alt }) => {
-              return <img src={src} alt={alt} key={uuidv4()} />;
+              return src ? <img src={src} alt={alt} key={uuidv4()} /> : loading;
             })
-          : []}
+          : loading}
       </ProductImagesComponent>
       <PriceWrapper>
         <Price>
@@ -25,12 +27,12 @@ export default function Product() {
           <small>ou em até 12x de</small>
           <p>
             R${" "}
-            {productData
+            {productData?.price
               ? (parseInt(productData.price) / 12)
                   .toFixed(2)
                   .toString()
                   .replace(".", ",")
-              : []}
+              : loading}
           </p>
         </FowardPrice>
       </PriceWrapper>
@@ -131,4 +133,9 @@ const ProductImagesComponent = styled.article`
 
 const PriceWrapper = styled.div`
   align-self: flex-start;
+  margin-right: 1.5rem;
+
+  @media (min-width: 750px) {
+    align-self: center;
+  }
 `;

--- a/src/components/ProductPage/TabsComponent.js
+++ b/src/components/ProductPage/TabsComponent.js
@@ -93,6 +93,7 @@ const StyledTabs = styled.div`
     flex-direction: column;
     @media (min-width: 750px) {
       flex-direction: row;
+      align-items: center;
       gap: 1.5rem;
     }
   }

--- a/src/components/ProductPage/index.js
+++ b/src/components/ProductPage/index.js
@@ -10,7 +10,6 @@ import ProductDataContext from "../../context/ProductDataContext";
 import UserInfoContext from "../../context/UserInfoContext";
 import TabsComponent from "./TabsComponent";
 import Header from "../Header";
-
 import ProductCard from "../ProductCard";
 
 export default function ProductPage() {
@@ -42,7 +41,7 @@ export default function ProductPage() {
     }
   }, []); //eslint-disable-line
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, behavior: "smooth" });
     getProduct();
   }, [window.location.pathname]); // eslint-disable-line
 
@@ -125,8 +124,8 @@ export default function ProductPage() {
       <ProductPageComponent>
         <span className="topBar">
           <ArrowIcon onClick={() => navigate(-1)} className="arrowIcon" />
-          <span className="cartIconContainer">
-            <CartIcon onClick={() => navigate("/cart")} className="cartIcon" />
+          <span onClick={() => navigate("/cart")} className="cartIconContainer">
+            <CartIcon className="cartIcon" />
             {getTotal() > 0 ? (
               <div className="cartProductIndicator">{getTotal()}</div>
             ) : (


### PR DESCRIPTION
Alterei um pouco o media-query da página de descrição do produto. Adicionei também um loading para aparecer enquanto os preços do produto são carregados ao invés de NaN, na tela de descrição de produtos. 